### PR TITLE
applyPrefix for CSS resources to True

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,6 +5,10 @@ History
 2.1dev
 ------
 
+- Set applyPrefix for CSS resources to True, so that referenced images can
+  still be found.
+  [thet, 2014-05-06]
+
 - Integrate translations.
   [rnix, 2014-05-01]
 

--- a/src/yafowil/plone/setuphandlers.py
+++ b/src/yafowil/plone/setuphandlers.py
@@ -55,7 +55,7 @@ def setup_resource_registries(context):
             rel='stylesheet', title='', rendering='link', enabled=1,
             cookable=merge, compression='safe', cacheable=True,
             conditionalcomment='', authenticated=False, skipCooking=False,
-            applyPrefix=False)
+            applyPrefix=True)
     msg += '<br /><br />Javascripts (JS)'
     regjs = getToolByName(site, 'portal_javascripts')
     for record in _extract_resources('js'):


### PR DESCRIPTION
Set applyPrefix for CSS resources to True, so that referenced images can still be found.
(issue with merged yafowil array widget, where icon could not be found)
